### PR TITLE
Fix image loading

### DIFF
--- a/legodle_app/lib/models/lego_set.dart
+++ b/legodle_app/lib/models/lego_set.dart
@@ -18,7 +18,18 @@ class LegoSet {
       required this.pieces,
       required this.price,
       required this.year}) {
-    imageUrl = 'https://images.brickset.com/sets/images/$number.jpg';
+    // imageUrl = 'https://images.brickset.com/sets/images/$number.jpg';
+    // url above broken with signiture
+    //     ══╡ EXCEPTION CAUGHT BY IMAGE RESOURCE SERVICE ╞════════════════════════════════════════════════════
+    //    The following Event object was thrown resolving an image frame:
+    //       [object Event]
+    //
+    //    When the exception was thrown, this was the stack
+    //
+    //    Image provider: NetworkImage("https://images.brickset.com/sets/images/xxxx.jpg", scale: 1.0)
+    //    Image key: NetworkImage("https://images.brickset.com/sets/images/xxxx.jpg", scale: 1.0)
+    // ════════════════════════════════════════════════════════════════════════════════════════════════════
+    imageUrl = 'https://img.bricklink.com/ItemImage/SL/$number.png';
   }
 
   factory LegoSet.fromList(List<dynamic> list) {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/5e2d9a34-882b-41d4-8ad0-abb01bdfa356)


Started receiving this image error with the same code and Flutter version since last hosted online:

```
══╡ EXCEPTION CAUGHT BY IMAGE RESOURCE SERVICE ╞════════════════════════════════════════════════════
The following Event object was thrown resolving an image frame:
    [object Event]

When the exception was thrown, this was the stack

Image provider: NetworkImage("https://images.brickset.com/sets/images/xxxx.jpg", scale: 1.0)
Image key: NetworkImage("https://images.brickset.com/sets/images/xxxx.jpg", scale: 1.0)
════════════════════════════════════════════════════════════════════════════════════════════════════
```

This is potentially due to a change in the way _Brickset_ hosts its images.

Changed image address to _Bricklink_ (however, it is slightly lower quality, especially for older sets). It seems to work with the same ID for all sets.

This fix works in the most recent Flutter version also (Flutter 3.22.3).